### PR TITLE
Response Server Startup with Features

### DIFF
--- a/features/step_definitions/server_mode.rb
+++ b/features/step_definitions/server_mode.rb
@@ -12,7 +12,12 @@ Given(/^I start `(.+)`$/) do |server_command|
   Dir.chdir "#{@root}/tmp/aruba" do
     command = "#{@root.join('bin')}/#{server_command}"
     @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(command)
-    sleep 2 # so the daemon has a chance to boot
+    Timeout.timeout(8) do
+      loop do
+        line = @stderr.gets
+        break if line =~ /start/
+      end
+    end
   end
   unless @wait_thr.alive?
     warn "STDERR: #{@stderr.read}"


### PR DESCRIPTION
Instead of waiting a flat two seconds before testing the webserver
changing the pattern to watch standard error for the message that
webrick has started
